### PR TITLE
GraphDB data-storage POC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN pip install /app
 ENV PKG_NAME=${PKG_NAME}
 
 # Tell docker to execute `docker_wrapper()` when the image is run.
-CMD python -c "from vantage6.tools.docker_wrapper import docker_wrapper; docker_wrapper('${PKG_NAME}')"
+CMD python -c "from v6_carrier_py.docker_wrapper import docker_wrapper; docker_wrapper('${PKG_NAME}')"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ pycodestyle==2.0.0
 pytest
 pytest-coverage
 prospector[with_pyroma]
-rdflib==5.0.0
+sparql-client==3.7
 vantage6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-vantage6
-pandas
+coveralls
 git+https://github.com/IKNL/vantage6-toolkit
+pandas
 pycodestyle==2.0.0
 pytest
 pytest-coverage
 prospector[with_pyroma]
-coveralls
+rdflib==5.0.0
+vantage6

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     packages=find_packages(),
     python_requires='>=3.6',
     install_requires=[
+        'rdflib'
         # 'vantage6-client'
     ]
     # ,

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages(),
     python_requires='>=3.6',
     install_requires=[
-        'rdflib'
+        'sparql-client'
         # 'vantage6-client'
     ]
     # ,

--- a/v6_carrier_py/algorithms.py
+++ b/v6_carrier_py/algorithms.py
@@ -1,4 +1,7 @@
+import os
+
 import pandas as pd
+import sparql
 from vantage6.tools.util import info
 
 
@@ -26,3 +29,25 @@ def RPC_get_data(data: pd.DataFrame, *args, **kwargs):
 
     """
     return data
+
+
+def RPC_sample_sparqle_query(data: None, *args, **kwargs):
+    """
+    Get the transactions that where processed by server A (example query on toy
+    transactions dataset)
+    """
+    database_uri = os.environ["DATABASE_URI"]
+    # database_uri is prepended with the data folder in the vantage6 node setup.
+    # therefore we need to extract the actual database_uri for our db endpoint
+    endpoint = database_uri[database_uri.find('http'):]
+    q = '''
+    PREFIX log: <http://example.org/ont/transaction-log/>
+    PREFIX srv: <http://example.org/data/server/>
+
+        SELECT ?transaction where {
+            ?transaction log:processedBy srv:A
+        } limit 10
+    '''
+    print(f'Trying to send query to {endpoint}')
+    result = sparql.query(endpoint, q)
+    return [row[0] for row in result]

--- a/v6_carrier_py/algorithms.py
+++ b/v6_carrier_py/algorithms.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import rdflib
 from vantage6.tools.util import info
 
 
@@ -16,3 +17,10 @@ def RPC_column_names(data: pd.DataFrame, *args, **kwargs):
 
 def RPC_correlation_matrix(data: pd.DataFrame, *args, **kwargs):
     return data.corr()
+
+
+def RPC_get_printable_graph(data: rdflib.Graph, *args, **kwargs):
+    """
+    Return printable graph for turtle-based linked data
+    """
+    return data.serialize(format="turtle").decode("utf-8")

--- a/v6_carrier_py/docker_wrapper.py
+++ b/v6_carrier_py/docker_wrapper.py
@@ -1,0 +1,42 @@
+import os
+import pickle
+
+import rdflib
+from vantage6.tools.dispatch_rpc import dispact_rpc
+from vantage6.tools.util import info
+
+
+def docker_wrapper(module: str):
+    info(f"wrapper for {module}")
+
+    # read input from the mounted inputfile.
+    input_file = os.environ["INPUT_FILE"]
+    info(f"Reading input file {input_file}")
+
+    with open(input_file, "rb") as fp:
+        input_data = pickle.load(fp)
+
+    # all containers receive a token, however this is usually only
+    # used by the master method. But can be used by regular containers also
+    # for example to find out the node_id.
+    token_file = os.environ["TOKEN_FILE"]
+    info(f"Reading token file '{token_file}'")
+    with open(token_file) as fp:
+        token = fp.read().strip()
+
+    data_file = os.environ["DATABASE_URI"]
+    info(f"Using '{data_file}' as database")
+    # with open(data_file, "r") as fp:
+    g = rdflib.Graph()
+    data = g.parse(data_file, format='ttl')
+
+    # make the actual call to the method/function
+    info("Dispatching ...")
+    output = dispact_rpc(data, input_data, module, token)
+
+    # write output from the method to mounted output file. Which will be
+    # transfered back to the server by the node-instance.
+    output_file = os.environ["OUTPUT_FILE"]
+    info(f"Writing output to {output_file}")
+    with open(output_file, 'wb') as fp:
+        fp.write(pickle.dumps(output))

--- a/v6_carrier_py/docker_wrapper.py
+++ b/v6_carrier_py/docker_wrapper.py
@@ -1,7 +1,6 @@
 import os
 import pickle
 
-import rdflib
 from vantage6.tools.dispatch_rpc import dispact_rpc
 from vantage6.tools.util import info
 
@@ -24,14 +23,9 @@ def docker_wrapper(module: str):
     with open(token_file) as fp:
         token = fp.read().strip()
 
-    data_file = os.environ["DATABASE_URI"]
-    info(f"Using '{data_file}' as database")
-    # with open(data_file, "r") as fp:
-    g = rdflib.Graph()
-    data = g.parse(data_file, format='ttl')
-
     # make the actual call to the method/function
     info("Dispatching ...")
+    data = None
     output = dispact_rpc(data, input_data, module, token)
 
     # write output from the method to mounted output file. Which will be


### PR DESCRIPTION
Serves as a POC for using GraphDB RDF-store as a data source instead of .csv. Relates to https://github.com/CARRIER-project/vantage6-local-setup/pull/2.

Add `sample_sparqle_query`: sample algorithm that does a simple sparqle query on toy data in RDF store as setup in https://github.com/CARRIER-project/vantage6-local-setup/pull/2,
add custom docker_wrapper that does not assume a specific datasource,