### PR TITLE
Add encryption of identifiers

### DIFF
--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -1,0 +1,43 @@
+import pytest
+
+from v6_carrier_py.encryption import salthash, encrypt_identifiers
+import pandas as pd
+import numpy as np
+
+
+def test_salthash():
+    salt = 'a' * 128
+    string = 'hash me please'
+    result = salthash(salt, string)
+    assert result == 'EQ2Fczw0MVu0zqH30I0Vffbkga7SJO9tmnWjU2ZNf9gJeHa' \
+                     'EETF9wJY13YPqdhsVwSMK1v+zVYYB6cgjDjHIjA=='
+
+
+class TestEncryptIdentifiers:
+    test_df = pd.DataFrame.from_dict({
+        'identifier1': ['a', 'b'],
+        'identifier2': ['c', 'd'],
+        'value1': [1, 2]
+    })
+    test_identifiers = ['identifier1', 'identifier2']
+    test_salt = 'a' * 128
+
+    def test_encrypt_identifiers(self):
+        result_df = encrypt_identifiers(self.test_df, self.test_salt,
+                                        identifiers=self.test_identifiers)
+        for identifier in self.test_identifiers:
+            assert identifier not in result_df
+        assert 'encrypted_identifier' in result_df
+
+    def test_encrypt_identifiers_wrong_identifiers(self):
+        test_wrong_identifiers = ['wrong_variable']
+        with pytest.raises(KeyError):
+            encrypt_identifiers(self.test_df, self.test_salt,
+                                identifiers=test_wrong_identifiers)
+
+    def test_encrypt_identifiers_null_values(self):
+        test_df = self.test_df.copy()
+        test_df['identifier1'] = np.nan
+        with pytest.raises(ValueError):
+            encrypt_identifiers(test_df, self.test_salt,
+                                identifiers=self.test_identifiers)

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -2,7 +2,6 @@ import pytest
 
 from v6_carrier_py.encryption import salthash, encrypt_identifiers
 import pandas as pd
-import numpy as np
 
 
 def test_salthash():
@@ -37,7 +36,7 @@ class TestEncryptIdentifiers:
 
     def test_encrypt_identifiers_null_values(self):
         test_df = self.test_df.copy()
-        test_df['identifier1'] = np.nan
+        test_df['identifier1'] = None
         with pytest.raises(ValueError):
             encrypt_identifiers(test_df, self.test_salt,
                                 identifiers=self.test_identifiers)

--- a/v6_carrier_py/encryption.py
+++ b/v6_carrier_py/encryption.py
@@ -5,24 +5,6 @@ from typing import List
 import pandas as pd
 
 
-def fixed_length_string(string: str, desired_length: int = 128):
-    """
-    Either truncate or padd a string with 'a' so that it is of the specified
-    length.
-    TODO: This is token from Chang's repo. Do we really want to support this or
-        just enforce 128 length salts?
-    Args:
-        string (str): String to be processed
-        desired_length (int): Desired length of the string
-    """
-    diff = desired_length - len(string)
-    if diff > 0:
-        string = string + ("a" * diff)
-    elif diff < 0:
-        string = string[:diff]
-    return string
-
-
 def salthash(salt, string):
     """
     Hash string using SHA 512 hashing with salt. Base64 encode resulting

--- a/v6_carrier_py/encryption.py
+++ b/v6_carrier_py/encryption.py
@@ -1,0 +1,71 @@
+from base64 import b64encode
+from hashlib import sha512
+from typing import List
+
+import pandas as pd
+
+
+def fixed_length_string(string: str, desired_length: int = 128):
+    """
+    Either truncate or padd a string with 'a' so that it is of the specified
+    length.
+    TODO: This is token from Chang's repo. Do we really want to support this or
+        just enforce 128 length salts?
+    Args:
+        string (str): String to be processed
+        desired_length (int): Desired length of the string
+    """
+    diff = desired_length - len(string)
+    if diff > 0:
+        string = string + ("a" * diff)
+    elif diff < 0:
+        string = string[:diff]
+    return string
+
+
+def salthash(salt, string):
+    """
+    Hash string using SHA 512 hashing with salt. Base64 encode resulting
+    hash.
+
+    Args:
+        salt (str): (random) string of length 128
+        string (str): arbitrary length string
+    Returns:
+        hashed 'salt + string'
+    Raises:
+        ValueError: if salt is not of length 128
+    """
+    if len(salt) != 128:
+        raise ValueError('Salt must be 128 bytes long.')
+    hashed = sha512((salt + string).encode('utf-8')).digest()
+    return b64encode(hashed).decode('utf-8')
+
+
+def encrypt_identifiers(df: pd.DataFrame, salt: str,
+                        identifiers: List[str]) -> pd.DataFrame:
+    """
+    Join identifiers (i.e. columns identifying a record) and hash them to
+    form an encrypted identifier. Drop original identifying columns.
+
+    Args:
+        df (pd.DataFrame): pandas dataframe
+        salt (str): salt to be used when hashing
+        identifiers (List(str)): column names of record identifiers
+
+    Returns:
+        (pd.DataFrame) with the column 'encrypted_identifier' instead of the
+            original identifier columns.
+    """
+    def _hash_identifiers(row):
+        try:
+            identifier_values = row[identifiers]
+        except KeyError as m:
+            raise KeyError(f'One of the identifying variables is not found in '
+                           f'the dataset, see original error: {m}')
+        if any(pd.isna(identifier_values)):
+            raise ValueError('One of the identifier values is NaN or None')
+        joined_ids = ''.join(identifier_values.apply(str)).replace(' ', '')
+        return salthash(salt, joined_ids)
+    df['encrypted_identifier'] = df.apply(_hash_identifiers, axis=1)
+    return df.drop(columns=identifiers)


### PR DESCRIPTION
Add encryption of identifiers.
The idea is that this will be used by an RPC function when needed. I did not implement the passing of the salt from configuration, but I guess that is trivial and can be done when needed.